### PR TITLE
chore: derive repo root for docker compose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+REPO_ROOT := $(shell git rev-parse --show-toplevel)
+COMPOSE_FILE := $(REPO_ROOT)/ops/docker-compose.yml
+
 .PHONY: up
 up:
-\tdocker compose -f ops/docker-compose.yml up --build
+	docker compose -f $(COMPOSE_FILE) up --build
+


### PR DESCRIPTION
## Summary
- reference docker-compose file using git-derived repo root so `make up` works from any directory

## Testing
- `pytest`
- `git rev-parse --show-toplevel`
- `make -n up`
- `cd ops && make -n -f ../Makefile up`


------
https://chatgpt.com/codex/tasks/task_e_68bf86f1f9908324ace3e7d4b9fccde9