### PR TITLE
Add basic API and UI with compose setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Project GOS
+
+This repository contains a minimal FastAPI backend and Streamlit UI.
+
+## Running locally with Docker Compose
+
+The included compose file starts both the API and UI services.
+
+```bash
+docker compose -f ops/docker-compose.yml up
+```
+
+- API available at: http://localhost:8000/health
+- UI available at: http://localhost:8501

--- a/api/main.py
+++ b/api/main.py
@@ -1,0 +1,15 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/health")
+def health() -> dict[str, bool]:
+    """Health check endpoint."""
+    return {"ok": True}
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/ops/docker-compose.yml
+++ b/ops/docker-compose.yml
@@ -3,8 +3,16 @@ services:
   api:
     image: python:3.11-slim
     working_dir: /app
-    command: bash -lc "pip install -r requirements.txt && uvicorn api.fastapi_app:app --host 0.0.0.0 --port 8000"
+    command: bash -lc "pip install -r requirements.txt && uvicorn api.main:app --host 0.0.0.0 --port 8000"
     volumes:
       - ./:/app
     ports:
       - "8000:8000"
+  ui:
+    image: python:3.11-slim
+    working_dir: /app
+    command: bash -lc "pip install -r requirements.txt && streamlit run ui/app.py --server.port 8501 --server.address 0.0.0.0"
+    volumes:
+      - ./:/app
+    ports:
+      - "8501:8501"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi==0.115.0
 uvicorn[standard]==0.30.6
 pydantic==2.9.2
+streamlit==1.39.0

--- a/ui/app.py
+++ b/ui/app.py
@@ -1,0 +1,16 @@
+import pandas as pd
+import streamlit as st
+
+st.set_page_config(page_title="Project GOS UI")
+
+st.title("Placeholder Dataset")
+
+# Sample dataset
+data = pd.DataFrame(
+    {
+        "Column A": [1, 2, 3],
+        "Column B": ["a", "b", "c"],
+    }
+)
+
+st.table(data)


### PR DESCRIPTION
## Summary
- implement FastAPI `/health` endpoint
- add Streamlit UI with placeholder dataset
- include docker-compose services and run instructions

## Testing
- `python -m py_compile api/main.py ui/app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf86f3849c8324a8dbae84f6bd8309