### PR TITLE
Add Streamlit dashboard with sample data

### DIFF
--- a/data/entities.csv
+++ b/data/entities.csv
@@ -1,0 +1,4 @@
+id,name,type
+1,Alice,Person
+2,Bob,Person
+3,Acme Corp,Organization

--- a/data/incidents.json
+++ b/data/incidents.json
@@ -1,0 +1,4 @@
+[
+  {"id": 1, "entity": 3, "date": "2023-01-15", "description": "Data breach at Acme Corp"},
+  {"id": 2, "entity": 1, "date": "2023-02-20", "description": "Phishing attempt on Alice"}
+]

--- a/data/links.csv
+++ b/data/links.csv
@@ -1,0 +1,3 @@
+source,target,relationship
+1,3,employee_of
+2,3,employee_of

--- a/ui/webapp/app.py
+++ b/ui/webapp/app.py
@@ -1,0 +1,25 @@
+import json
+from pathlib import Path
+
+import pandas as pd
+import streamlit as st
+
+st.title("OSINT Dashboard")
+st.write("Sample data from seeded files.")
+
+DATA_DIR = Path(__file__).resolve().parents[2] / "data"
+
+entities = pd.read_csv(DATA_DIR / "entities.csv")
+st.subheader("Entities")
+st.dataframe(entities)
+
+links = pd.read_csv(DATA_DIR / "links.csv")
+st.subheader("Links")
+st.dataframe(links)
+
+with open(DATA_DIR / "incidents.json", "r", encoding="utf-8") as f:
+    incidents = json.load(f)
+incidents_df = pd.DataFrame(incidents)
+
+st.subheader("Incidents")
+st.dataframe(incidents_df)

--- a/ui/webapp/placeholder.txt
+++ b/ui/webapp/placeholder.txt
@@ -1,1 +1,0 @@
- (panes: sitrep, graph, ttps, spice, game, assistant)


### PR DESCRIPTION
## Summary
- replace placeholder with a basic Streamlit app that loads data files
- seed sample entities, links and incident records for the dashboard

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf9085bd688324a6bd961f58600a19