### PR TITLE
docs: add UI quick start instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,29 @@ Run database migrations:
 make migrate
 ```
 ## Overview
-Project GOS is a modular framework for open-source intelligence (OSINT) and psychological operations simulation. It combines tools like SP!CE and DISARM to support research and experimentation.
+Project GOS is a modular framework for open-source intelligence (OSINT) and psychological operations simulation. It combines tools like SP!CE and DISARM to support research and experimentation. The Streamlit dashboard serves as the primary entry point to the system, while the data pipelines and REST API can be used as optional add-ons.
+
+## UI Quick Start
+
+1. **Install dependencies**
+   ```bash
+   poetry install
+   ```
+2. **Point the UI at your data**
+   ```bash
+   export GOS_DATA_DIR=path/to/sample-data
+   ```
+   The dashboard reads from `GOS_DATA_DIR`; you can start with a sample dataset to explore the UI.
+3. **Run the dashboard**
+   ```bash
+   streamlit run ui/webapp/app.py
+   ```
+
+Supporting services (e.g., the database) can be started and stopped with the existing Makefile targets:
+```bash
+make up    # start services
+make down  # stop services
+```
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary
- clarify that the Streamlit dashboard is the primary entry point
- document a UI Quick Start section with dependency install, `GOS_DATA_DIR`, and Streamlit run command
- note Makefile targets for starting and stopping supporting services

## Testing
- `make test` *(fails: no tests were collected)*

------
https://chatgpt.com/codex/tasks/task_e_68bf908c49e08324ab6b6fc77762f647