### PR TITLE
Implement event ingestion pipeline and persistence

### DIFF
--- a/pipeline/enrich/enrich.py
+++ b/pipeline/enrich/enrich.py
@@ -1,1 +1,15 @@
+from __future__ import annotations
+from typing import Any, Dict, Tuple
 
+
+def enrich_event(event: Dict[str, Any]) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    """Enrich an event with additional context.
+
+    Returns the enriched event and any metadata generated during enrichment.
+    """
+    metadata: Dict[str, Any] = {"source": "stub"}
+    # Example enrichment flag
+    feats = event.get("feats", {})
+    feats["enriched"] = True
+    event["feats"] = feats
+    return event, metadata

--- a/pipeline/graph/neo4j_client.py
+++ b/pipeline/graph/neo4j_client.py
@@ -1,1 +1,11 @@
+from __future__ import annotations
+from typing import Any, Dict
 
+
+def upsert_event(event: Dict[str, Any]) -> None:
+    """Persist an event to Neo4j.
+
+    This is a stub that simulates graph persistence.
+    """
+    # In a real implementation this would use the Neo4j driver.
+    return None

--- a/pipeline/ingest/ingest.py
+++ b/pipeline/ingest/ingest.py
@@ -1,1 +1,15 @@
+from __future__ import annotations
+from typing import Any, Dict
+from uuid import uuid4
+from datetime import datetime
 
+
+def ingest_event(event: Dict[str, Any]) -> Dict[str, Any]:
+    """Prepare a raw event for processing.
+
+    Ensures the event has an ``event_id`` and timestamp.
+    """
+    evt = dict(event)
+    evt.setdefault("event_id", str(uuid4()))
+    evt.setdefault("ts", datetime.utcnow())
+    return evt

--- a/pipeline/normalize/normalize.py
+++ b/pipeline/normalize/normalize.py
@@ -1,1 +1,10 @@
+from __future__ import annotations
+from typing import Any, Dict
 
+
+def normalize_event(event: Dict[str, Any]) -> Dict[str, Any]:
+    """Normalize the structure of an event.
+
+    For now this is a passthrough stub.
+    """
+    return dict(event)

--- a/tests/test_ingest_event.py
+++ b/tests/test_ingest_event.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from datetime import datetime
+from fastapi.testclient import TestClient
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from api.fastapi_app import app, engine, event_table, metadata
+
+
+def reset_db() -> None:
+    metadata.drop_all(engine)
+    metadata.create_all(engine)
+
+
+def test_ingest_event_success():
+    reset_db()
+    client = TestClient(app)
+    evt = {
+        "event_id": "evt1",
+        "ts": datetime.utcnow().isoformat(),
+        "src": "unit-test",
+        "content": {"msg": "hi"},
+    }
+    resp = client.post("/ingest/event", json=evt, headers={"X-API-Key": "dev-key"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["event_id"] == "evt1"
+    assert body["enrichment"]["source"] == "stub"
+    with engine.begin() as conn:
+        rows = conn.execute(event_table.select()).fetchall()
+        assert len(rows) == 1
+
+
+def test_ingest_event_error(monkeypatch):
+    reset_db()
+    client = TestClient(app)
+    evt = {
+        "event_id": "evt2",
+        "ts": datetime.utcnow().isoformat(),
+        "src": "unit-test",
+        "content": {"msg": "hi"},
+    }
+
+    def boom(event):  # type: ignore[unused-argument]
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("api.fastapi_app.enrich_event", boom)
+
+    resp = client.post("/ingest/event", json=evt, headers={"X-API-Key": "dev-key"})
+    assert resp.status_code == 500


### PR DESCRIPTION
## Summary
- Add ingestion pipeline stages and stub Neo4j client
- Persist ingested events to SQL database
- Return enrichment metadata from API
- Cover success and failure paths for event ingestion API

## Testing
- `ruff check api pipeline tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf939b1380832484839437136f7a9d