### PR TITLE
Add configurable tick loop policy simulation

### DIFF
--- a/sim/tickloop.py
+++ b/sim/tickloop.py
@@ -1,11 +1,68 @@
-# Minimal simulation stub; replace with real loop.
-def predict_policy_impact(campaign_id, s_amp=None, s_share=None, dsn=None):
+"""Simple simulation loop for campaign reach.
+
+This module provides :func:`predict_policy_impact` which performs a very
+small agent-based style simulation.  The goal of the function is not to be a
+fully fledged simulator but rather a deterministic toy model that the tests
+can exercise.
+
+The model tracks an abstract ``reach`` value for a campaign.  ``reach`` starts
+at a baseline value and is modified on each tick by two configurable
+parameters:
+
+``network``
+    Represents the strength of network effects.  The higher the value, the
+    more the current reach grows due to sharing.
+
+``decay``
+    Models saturation or audience loss between ticks.
+
+Both parameters are multiplied by the share/amplify scalars supplied by the
+caller so that tests can easily tweak scenarios.
+"""
+
+
+def predict_policy_impact(
+    campaign_id,  # type: ignore[unused-argument]
+    s_amp=None,
+    s_share=None,
+    network: float = 0.0,
+    decay: float = 0.0,
+    ticks: int = 10,
+    dsn=None,  # type: ignore[unused-argument]
+):
+    """Evolve a campaign for a number of ticks.
+
+    The function returns a dictionary containing the trajectory of the reach
+    as well as the final ``projected_reach`` after ``ticks`` iterations.  All
+    parameters default to no change so that the baseline is a flat line.
+    """
+
     base = 1000
     amp = s_amp if s_amp is not None else 1.0
     shr = s_share if s_share is not None else 1.0
+
+    reach = base * amp
+    trajectory = [int(reach)]
+
+    for _ in range(ticks):
+        # Apply network effects and decay at each tick.  Casting to ``float``
+        # ensures any callers using ``Decimal`` or other numeric types behave
+        # predictably.
+        reach = float(reach) * (1 + network * shr)
+        reach *= 1 - decay
+        trajectory.append(int(reach))
+
     return {
         "baseline_reach": base,
-        "projected_reach": int(base*amp*(1+0.5*shr)),
-        "eta": {"amplify": amp, "share": shr}
+        "projected_reach": trajectory[-1],
+        "trajectory": trajectory,
+        "params": {
+            "amplify": amp,
+            "share": shr,
+            "network": network,
+            "decay": decay,
+            "ticks": ticks,
+        },
     }
+
 

--- a/tests/test_tickloop.py
+++ b/tests/test_tickloop.py
@@ -1,0 +1,18 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from sim.tickloop import predict_policy_impact
+
+
+def test_predict_policy_impact_constant():
+    res = predict_policy_impact("camp", s_amp=1, s_share=1, network=0, decay=0, ticks=3)
+    assert res["trajectory"] == [1000, 1000, 1000, 1000]
+    assert res["projected_reach"] == 1000
+
+
+def test_predict_policy_impact_growth_decay():
+    res = predict_policy_impact("camp", s_amp=1, s_share=1, network=0.2, decay=0.1, ticks=3)
+    assert res["trajectory"] == [1000, 1080, 1166, 1259]
+    assert res["projected_reach"] == 1259


### PR DESCRIPTION
## Summary
- expand `predict_policy_impact` into a tick-based simulation with network and decay parameters
- record reach trajectory and final impact across ticks
- test scenarios for flat and growing campaigns

## Testing
- `pytest tests/test_tickloop.py -q`
- `pytest -q` *(fails: SyntaxError in pipeline modules: "from __future__ imports must occur at the beginning of the file")*


------
https://chatgpt.com/codex/tasks/task_e_68bf9bf31f708324913c11de5d597761