### PR TITLE
Add DISARM sync and registry search

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,27 @@ poetry install
 poetry run python main.py
 ```
 
+## DISARM Tactic Registry
+
+The DISARM data set can be synchronised into the local database and queried via
+the `DisarmRegistry` utility.  By default, an in-memory SQLite database is used;
+set `DATABASE_URL` to override this.  To import tactics, place a `tactics.json`
+file in `external/disarm` or specify a custom path with `DISARM_TACTICS_FILE`,
+then run:
+
+```bash
+python -m core.disarm.sync
+```
+
+After syncing, tactics can be searched programmatically:
+
+```python
+from core.disarm.registry import DisarmRegistry
+
+reg = DisarmRegistry()
+print(reg.search(q="disinformation"))
+```
+
 ## Architecture
 ![Architecture Diagram Placeholder](docs/architecture.png)
 

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,1 @@
+# Core package

--- a/core/disarm/registry.py
+++ b/core/disarm/registry.py
@@ -1,4 +1,55 @@
-# Placeholder registry; replace with DB-backed search.
+"""DISARM tactic registry backed by the local database."""
+
+from __future__ import annotations
+
+import os
+
+from sqlalchemy import Column, MetaData, String, Table, create_engine, func, select
+from sqlalchemy.pool import StaticPool
+
+
+def _engine_from_env():
+    url = os.getenv("DATABASE_URL", "sqlite://")
+    if url.startswith("sqlite"):
+        return create_engine(
+            url,
+            future=True,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+    return create_engine(url, future=True)
+
+
+def _tactic_table(metadata: MetaData) -> Table:
+    return Table(
+        "disarm_tactic",
+        metadata,
+        Column("tactic_id", String, primary_key=True),
+        Column("name", String, nullable=False),
+        Column("description", String, nullable=False),
+        Column("phase", String, nullable=True),
+    )
+
+
 class DisarmRegistry:
-    def search(self, q: str = "", phase: str | None = None):
-        return []
+    """Simple wrapper around the ``disarm_tactic`` table."""
+
+    def __init__(self) -> None:
+        self.engine = _engine_from_env()
+        self.metadata = MetaData()
+        self.table = _tactic_table(self.metadata)
+        self.metadata.create_all(self.engine)
+
+    def search(self, q: str = "", phase: str | None = None) -> list[dict]:
+        stmt = select(self.table)
+        if q:
+            like = f"%{q.lower()}%"
+            stmt = stmt.where(
+                func.lower(self.table.c.name).like(like)
+                | func.lower(self.table.c.description).like(like)
+            )
+        if phase:
+            stmt = stmt.where(self.table.c.phase == phase)
+        with self.engine.begin() as conn:
+            rows = conn.execute(stmt).mappings().all()
+        return [dict(r) for r in rows]

--- a/core/disarm/sync.py
+++ b/core/disarm/sync.py
@@ -1,3 +1,111 @@
-# TODO: add DISARM submodule sync + DB upsert here
-if __name__ == "__main__":
-    print("Run: git submodule add <DISARM_GIT_URL> external/disarm")
+"""Sync DISARM tactics into the local database.
+
+The script expects the DISARM repository to exist as a git submodule at
+``external/disarm``.  The path to the JSON file containing the tactics can be
+overridden with the ``DISARM_TACTICS_FILE`` environment variable.  Each tactic
+record must provide ``tactic_id``, ``name``, ``description`` and ``phase``
+fields.
+
+Running the sync will pull the submodule and upsert the tactics into the
+``disarm_tactic`` table.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import subprocess
+from typing import Iterable
+
+from sqlalchemy import Column, MetaData, String, Table, create_engine
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy.pool import StaticPool
+
+
+# Database --------------------------------------------------------------------
+
+def _engine_from_env():
+    url = os.getenv("DATABASE_URL", "sqlite://")
+    if url.startswith("sqlite"):
+        return create_engine(
+            url,
+            future=True,
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+    return create_engine(url, future=True)
+
+
+def _tactic_table(metadata: MetaData) -> Table:
+    return Table(
+        "disarm_tactic",
+        metadata,
+        Column("tactic_id", String, primary_key=True),
+        Column("name", String, nullable=False),
+        Column("description", String, nullable=False),
+        Column("phase", String, nullable=True),
+    )
+
+
+# Sync routine ----------------------------------------------------------------
+
+def _load_tactics(path: pathlib.Path) -> Iterable[dict]:
+    with path.open("r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    if not isinstance(data, list):  # pragma: no cover - defensive
+        raise TypeError("Tactic data must be a list of objects")
+    return data
+
+
+def sync() -> None:
+    """Pull the DISARM repository and upsert tactics into the database."""
+
+    disarm_repo = pathlib.Path(os.getenv("DISARM_REPO", "external/disarm"))
+    tactics_file = os.getenv("DISARM_TACTICS_FILE")
+    if tactics_file:
+        tactics_path = pathlib.Path(tactics_file)
+    else:
+        tactics_path = disarm_repo / "tactics.json"
+
+    # Update the submodule; ignore errors if it is not configured yet.
+    subprocess.run(
+        [
+            "git",
+            "submodule",
+            "update",
+            "--init",
+            "--recursive",
+            str(disarm_repo),
+        ],
+        check=False,
+    )
+
+    engine = _engine_from_env()
+    metadata = MetaData()
+    table = _tactic_table(metadata)
+    metadata.create_all(engine)
+
+    tactics = _load_tactics(tactics_path)
+
+    with engine.begin() as conn:
+        for t in tactics:
+            stmt = sqlite_insert(table).values(
+                tactic_id=t["tactic_id"],
+                name=t["name"],
+                description=t.get("description", ""),
+                phase=t.get("phase"),
+            )
+            stmt = stmt.on_conflict_do_update(
+                index_elements=[table.c.tactic_id],
+                set_={
+                    "name": t["name"],
+                    "description": t.get("description", ""),
+                    "phase": t.get("phase"),
+                },
+            )
+            conn.execute(stmt)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    sync()

--- a/tests/test_disarm_registry.py
+++ b/tests/test_disarm_registry.py
@@ -1,0 +1,45 @@
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from core.disarm.registry import DisarmRegistry
+from core.disarm.sync import sync
+
+
+def _write_sample(tmp_path: Path) -> None:
+    disarm_dir = tmp_path / "external" / "disarm"
+    disarm_dir.mkdir(parents=True)
+    tactics = [
+        {
+            "tactic_id": "TA01",
+            "name": "Tactic One",
+            "description": "Alpha tactic",
+            "phase": "Plan",
+        },
+        {
+            "tactic_id": "TA02",
+            "name": "Tactic Two",
+            "description": "Bravo tactic",
+            "phase": "Act",
+        },
+    ]
+    (disarm_dir / "tactics.json").write_text(json.dumps(tactics))
+    os.environ["DISARM_TACTICS_FILE"] = str(disarm_dir / "tactics.json")
+
+
+def test_search_filters(tmp_path):
+    db_path = tmp_path / "t.db"
+    os.environ["DATABASE_URL"] = f"sqlite:///{db_path}"
+    _write_sample(tmp_path)
+    sync()
+
+    reg = DisarmRegistry()
+    all_rows = reg.search(q="tactic")
+    assert {r["tactic_id"] for r in all_rows} == {"TA01", "TA02"}
+
+    plan_rows = reg.search(q="tactic", phase="Plan")
+    assert len(plan_rows) == 1
+    assert plan_rows[0]["tactic_id"] == "TA01"


### PR DESCRIPTION
## Summary
- implement sync script to pull DISARM data and upsert tactics into SQLite or configured DB
- add database-backed `DisarmRegistry` search
- document DISARM registry configuration and add tests

## Testing
- `pytest tests/test_disarm_registry.py`
- `make test` *(fails: SyntaxError: from __future__ imports must occur at the beginning of the file in pipeline modules)*

------
https://chatgpt.com/codex/tasks/task_e_68bf9befc09483249aa72899d24f704d