### PR TITLE
Wire Neo4j client into graph pipeline

### DIFF
--- a/pipeline/enrich/enrich.py
+++ b/pipeline/enrich/enrich.py
@@ -35,8 +35,6 @@ The primary entry point is :func:`enrich_event` which accepts an
 populated.
 """
 
-from __future__ import annotations
-
 import json
 import os
 import re
@@ -207,7 +205,7 @@ def compute_bot_likelihood(text: str) -> float:
 # ---------------------------------------------------------------------------
 
 
-def enrich_event(event: EventIn) -> EventIn:
+def enrich(event: EventIn) -> EventIn:
     """Return a copy of ``event`` with its ``feats`` field populated."""
 
     text = ""
@@ -230,5 +228,5 @@ __all__ = [
     "compute_sentiment",
     "compute_topics",
     "compute_bot_likelihood",
-    "enrich_event",
+    "enrich",
 ]

--- a/pipeline/graph/neo4j_client.py
+++ b/pipeline/graph/neo4j_client.py
@@ -1,14 +1,37 @@
 from __future__ import annotations
+import os
 from typing import Any, Dict
 
 
 def upsert_event(event: Dict[str, Any]) -> None:
     """Persist an event to Neo4j.
 
-    This is a stub that simulates graph persistence.
+    Instantiate :class:`Neo4jClient` using connection parameters from
+    environment variables and write the provided ``event`` to the graph.
+    ``event`` is expected to be a mapping compatible with
+    :class:`api.schemas.EventIn`.
     """
-    # In a real implementation this would use the Neo4j driver.
-    return None
+
+    uri = os.getenv("NEO4J_URI", "bolt://localhost:7687")
+    user = os.getenv("NEO4J_USER", "neo4j")
+    password = os.getenv("NEO4J_PASSWORD", "test")
+    database = os.getenv("NEO4J_DATABASE") or None
+
+    try:
+        client = Neo4jClient(uri, user, password, database)
+    except Exception:  # pragma: no cover - optional dependency or connection
+        logger.warning("Neo4j client unavailable", exc_info=True)
+        return
+
+    try:
+        client.write_event(EventIn(**event))
+    except Exception:  # pragma: no cover - write issues
+        logger.warning("Neo4j write failed", exc_info=True)
+    finally:
+        try:
+            client.close()
+        except Exception:  # pragma: no cover - close errors
+            logger.warning("Failed to close Neo4j client", exc_info=True)
 """Neo4j client utilities for Project GOS.
 
 This module exposes a small wrapper around the official Neo4j Python
@@ -17,14 +40,19 @@ objects to the graph while ensuring the constraints defined in
 ``db/cypher_constraints.cql`` are present.  Basic logging and exception
 handling are included so callers can understand when writes fail.
 """
-
-from __future__ import annotations
-
 import logging
 from pathlib import Path
 from typing import Any, Dict
 
-from neo4j import Driver, GraphDatabase
+try:  # pragma: no cover - optional dependency
+    from neo4j import Driver, GraphDatabase
+except Exception:  # pragma: no cover - import fallback
+    Driver = Any  # type: ignore
+
+    class GraphDatabase:  # type: ignore
+        @staticmethod
+        def driver(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401 - dynamic
+            raise RuntimeError("neo4j driver is not installed")
 
 from api.schemas import EventIn
 

--- a/pipeline/ingest/ingest.py
+++ b/pipeline/ingest/ingest.py
@@ -27,8 +27,6 @@ intended for documentation and testing.  Real implementations would include
 HTTP requests, authentication and error handling for the respective APIs.
 """
 
-from __future__ import annotations
-
 from datetime import datetime
 from email.utils import parsedate_to_datetime
 from typing import Any, Callable, Dict
@@ -195,7 +193,7 @@ CONNECTORS: Dict[str, Callable[[Dict[str, Any]], Dict[str, Any]]] = {
 }
 
 
-def ingest_event(raw: Dict[str, Any], source: str) -> EventIn:
+def ingest_payload(raw: Dict[str, Any], source: str) -> EventIn:
     """Convert a raw event payload into an :class:`EventIn` instance.
 
     Parameters

--- a/pipeline/normalize/normalize.py
+++ b/pipeline/normalize/normalize.py
@@ -25,8 +25,6 @@ The main entry point is :func:`normalize` which accepts an ``EventIn`` and
 returns a new, normalized ``EventIn``.
 """
 
-from __future__ import annotations
-
 import html
 import re
 import urllib.request

--- a/tests/test_graph_upsert.py
+++ b/tests/test_graph_upsert.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from datetime import datetime
+from unittest.mock import MagicMock, patch
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from api.schemas import EventIn
+from pipeline.graph.neo4j_client import upsert_event
+
+
+def test_upsert_event_calls_client(monkeypatch):
+    monkeypatch.setenv("NEO4J_URI", "bolt://example.com")
+    monkeypatch.setenv("NEO4J_USER", "user")
+    monkeypatch.setenv("NEO4J_PASSWORD", "pass")
+    monkeypatch.setenv("NEO4J_DATABASE", "db")
+
+    event = {
+        "event_id": "evt1",
+        "ts": datetime.utcnow(),
+        "src": "unit-test",
+        "content": {"text": "hello"},
+    }
+
+    mock_client = MagicMock()
+    with patch("pipeline.graph.neo4j_client.Neo4jClient", return_value=mock_client) as mock_cls:
+        upsert_event(event)
+
+    mock_cls.assert_called_once_with("bolt://example.com", "user", "pass", "db")
+    mock_client.write_event.assert_called_once()
+    arg = mock_client.write_event.call_args[0][0]
+    assert isinstance(arg, EventIn)
+    assert arg.event_id == "evt1"
+    mock_client.close.assert_called_once()


### PR DESCRIPTION
## Summary
- Instantiate `Neo4jClient` in `upsert_event` using environment driven config
- Fallback gracefully when Neo4j driver unavailable and ensure client cleanup
- Add unit test verifying `upsert_event` uses `Neo4jClient` and passes event model
- Fix pipeline modules (ingest, normalize, enrich) to avoid import-time issues

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf9bf0899c8324b310fd5a5d28afb9