### PR TITLE
Add CATMA machine and policy utilities with tests

### DIFF
--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,1 +1,10 @@
-# Core package
+"""Core package utilities.
+
+The package exposes a tiny subset of the engine API at the top level for
+convenience during experiments and in the test-suite.
+"""
+
+from .engines.catma import Machine, Policy, evaluate_path, enumerate_paths, best_path
+
+__all__ = ["Machine", "Policy", "evaluate_path", "enumerate_paths", "best_path"]
+

--- a/core/engines/catma.py
+++ b/core/engines/catma.py
@@ -1,2 +1,171 @@
-  # machines, policy (η), path math
-python
+r"""CATMA engine.
+
+This module provides small utilities to model *machines* (finite state
+machines), evaluate a policy :math:`\eta` on those machines and perform basic
+path mathematics.  The goal is not to be feature complete but to supply the
+minimal capabilities needed by the tests in this kata.
+
+The public API intentionally mirrors common terminology used in the project::
+
+    >>> m = Machine(start="A", transitions={"A": {"x": "B"}, "B": {}})
+    >>> def policy(state, action):
+    ...     return 0.5
+    >>> evaluate_path(m, ["x"], policy)
+    0.5
+
+The functions are small but well documented and type hinted to make them easy
+to reason about during experimentation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Dict, Iterable, List, Tuple
+
+
+# ---------------------------------------------------------------------------
+# Types
+
+Policy = Callable[[str, str], float]
+r"""Callable describing the policy :math:`\eta`.
+
+The callable receives the current ``state`` and an ``action`` and must return
+the weight/probability for taking that action.  The return value is multiplied
+across a path when evaluating it.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Machine definition
+
+
+@dataclass
+class Machine:
+    """Simple finite state machine.
+
+    Parameters
+    ----------
+    start:
+        The name of the starting state.
+    transitions:
+        Nested mapping of ``state -> action -> next_state``.
+
+    Only the functionality needed by the tests is implemented: stepping
+    through transitions and walking a sequence of actions.
+    """
+
+    start: str
+    transitions: Dict[str, Dict[str, str]]
+
+    # --- helper methods -------------------------------------------------
+
+    def step(self, state: str, action: str) -> str:
+        """Return the next state when performing ``action`` from ``state``.
+
+        Raises
+        ------
+        KeyError
+            If the state or action is unknown.
+        """
+
+        try:
+            return self.transitions[state][action]
+        except KeyError as exc:  # pragma: no cover - simple error wrapping
+            raise KeyError(f"No transition defined for state {state!r} and action {action!r}") from exc
+
+    def walk(self, actions: Iterable[str]) -> List[str]:
+        """Traverse the machine following ``actions``.
+
+        Returns a list of visited states including the start state.
+        """
+
+        state = self.start
+        path = [state]
+        for action in actions:
+            state = self.step(state, action)
+            path.append(state)
+        return path
+
+
+# ---------------------------------------------------------------------------
+# Policy / path mathematics
+
+
+def evaluate_path(machine: Machine, actions: Iterable[str], policy: Policy) -> float:
+    """Evaluate a path's value under ``policy``.
+
+    ``policy`` is called for each ``(state, action)`` pair and the returned
+    weights are multiplied across the path.  The final product is returned.
+    """
+
+    value = 1.0
+    state = machine.start
+    for action in actions:
+        weight = policy(state, action)
+        value *= weight
+        state = machine.step(state, action)
+    return value
+
+
+def enumerate_paths(machine: Machine, depth: int) -> List[List[str]]:
+    """Enumerate all state paths up to ``depth`` transitions.
+
+    The returned list contains paths represented as lists of states.  The start
+    state itself is included as a path of length ``0``.
+    """
+
+    paths: List[List[str]] = []
+
+    def dfs(state: str, path: List[str], remaining: int) -> None:
+        paths.append(path.copy())
+        if remaining == 0:
+            return
+        for _action, nxt in machine.transitions.get(state, {}).items():
+            dfs(nxt, path + [nxt], remaining - 1)
+
+    dfs(machine.start, [machine.start], depth)
+    return paths
+
+
+def best_path(machine: Machine, depth: int, policy: Policy) -> Tuple[List[str], float]:
+    """Return the path (up to ``depth`` transitions) with the highest value.
+
+    The evaluation uses ``policy`` in the same way as :func:`evaluate_path`.
+
+    Returns
+    -------
+    tuple
+        A ``(path, value)`` pair where ``path`` is the list of states and
+        ``value`` is the cumulative policy value for that path.
+    """
+
+    # Start with an impossible value to ensure any real path replaces it.
+    best: Tuple[List[str], float] = ([], float("-inf"))
+
+    def dfs(state: str, path: List[str], value: float, remaining: int) -> None:
+        nonlocal best
+        # Evaluate paths that either exhausted the depth or reached a leaf node
+        if remaining == 0 or not machine.transitions.get(state):
+            if value > best[1]:
+                best = (path.copy(), value)
+        if remaining == 0:
+            return
+        for action, nxt in machine.transitions.get(state, {}).items():
+            weight = policy(state, action)
+            dfs(nxt, path + [nxt], value * weight, remaining - 1)
+
+    dfs(machine.start, [machine.start], 1.0, depth)
+    if best[0]:
+        return best
+    # No transitions were explored; return start state with neutral value
+    return [machine.start], 1.0
+
+
+__all__ = [
+    "Machine",
+    "Policy",
+    "evaluate_path",
+    "enumerate_paths",
+    "best_path",
+]
+

--- a/tests/test_catma.py
+++ b/tests/test_catma.py
@@ -1,0 +1,62 @@
+"""Tests for the CATMA engine."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+# Make the repository importable when running the tests directly from the
+# checked-out sources.  This mirrors the style of other tests in the project.
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from core.engines.catma import Machine, evaluate_path, enumerate_paths, best_path
+
+
+def _machine() -> Machine:
+    """Return a small example machine used throughout the tests."""
+
+    transitions = {
+        "A": {"x": "B", "z": "C"},
+        "B": {"y": "C"},
+        "C": {},
+    }
+    return Machine(start="A", transitions=transitions)
+
+
+def _policy(state: str, action: str) -> float:
+    """Example policy providing weights for each transition."""
+
+    weights = {("A", "x"): 0.6, ("A", "z"): 0.4, ("B", "y"): 0.5}
+    return weights.get((state, action), 0.0)
+
+
+def test_walk_and_evaluate():
+    machine = _machine()
+    actions = ["x", "y"]
+
+    assert machine.walk(actions) == ["A", "B", "C"]
+    value = evaluate_path(machine, actions, _policy)
+    assert value == pytest.approx(0.6 * 0.5)
+
+
+def test_enumerate_paths():
+    machine = _machine()
+    paths = enumerate_paths(machine, depth=2)
+
+    # Expected paths (state sequences) up to two transitions
+    assert ["A"] in paths
+    assert ["A", "B"] in paths
+    assert ["A", "C"] in paths
+    assert ["A", "B", "C"] in paths
+    assert len(paths) == 4
+
+
+def test_best_path():
+    machine = _machine()
+    path, value = best_path(machine, depth=2, policy=_policy)
+
+    assert path == ["A", "C"]
+    # This path uses transition ('A','z') with weight 0.4
+    assert value == pytest.approx(0.4)
+


### PR DESCRIPTION
## Summary
- implement CATMA engine for defining machines and evaluating policy η
- expose CATMA helpers in core package
- add unit tests covering path evaluation, enumeration and best path selection

## Testing
- `pytest tests/test_catma.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'neo4j')*


------
https://chatgpt.com/codex/tasks/task_e_68bf9fefa5d88324a8a2e56b36bd9837