### PR TITLE
Expose engine modules via core.engines package

### DIFF
--- a/core/engines/__init__.py
+++ b/core/engines/__init__.py
@@ -1,0 +1,10 @@
+"""Engine modules exposed at :mod:`core.engines`.
+
+This package provides stub implementations of various analytical engines.  The
+modules are kept lightweight to ensure that importing ``core.engines`` works in
+minimal testing environments.
+"""
+
+from . import catma, game, updc
+
+__all__ = ["catma", "game", "updc"]

--- a/core/engines/catma.py
+++ b/core/engines/catma.py
@@ -1,2 +1,7 @@
-  # machines, policy (η), path math
-python
+"""Placeholder engine module for CATMA.
+
+This module currently acts as a stub ensuring that the package structure
+is importable. Actual engine logic will be added in future revisions.
+"""
+
+# machines, policy (η), path math

--- a/core/engines/game.py
+++ b/core/engines/game.py
@@ -1,2 +1,6 @@
+"""Placeholder engine module for game theory routines.
+
+This stub exists so that engine modules can be imported during testing.
+"""
+
 # strategies, payoffs, best-response
-python

--- a/core/engines/updc.py
+++ b/core/engines/updc.py
@@ -1,2 +1,6 @@
+"""Placeholder engine module for UPDC.
+
+This stub ensures the module can be imported via ``core.engines``.
+"""
+
 # I,S,M,W,n,R → RT,Q,CI
-python

--- a/tests/test_engines_import.py
+++ b/tests/test_engines_import.py
@@ -1,0 +1,13 @@
+"""Ensure engine modules can be imported via the ``core.engines`` package."""
+
+import importlib
+
+
+def test_engine_modules_importable() -> None:
+    """All known engine modules should be importable through ``core.engines``."""
+    # Import the package first to verify it is a regular package.
+    from core import engines
+
+    assert importlib.import_module("core.engines.catma") is engines.catma
+    assert importlib.import_module("core.engines.game") is engines.game
+    assert importlib.import_module("core.engines.updc") is engines.updc


### PR DESCRIPTION
## Summary
- add `core.engines` package initializer exporting available engine modules
- ensure engine stubs are importable and covered by tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'neo4j')*
- `pip install neo4j` *(fails: Cannot connect to proxy, 403)*
- `PYTHONPATH=. pytest tests/test_engines_import.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf9ff265f48324a45301e170a63396