### PR TITLE
Add domain models and scoring registry

### DIFF
--- a/core/schemas/__init__.py
+++ b/core/schemas/__init__.py
@@ -1,0 +1,5 @@
+"""Schema definitions for domain objects."""
+
+from .domain import Evidence, TTPRef, Actor, Observation, Scenario
+
+__all__ = ["Evidence", "TTPRef", "Actor", "Observation", "Scenario"]

--- a/core/schemas/domain.py
+++ b/core/schemas/domain.py
@@ -1,0 +1,45 @@
+"""Domain models used by scoring engines."""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+
+class Evidence(BaseModel):
+    """A single piece of supporting information for an observation."""
+
+    kind: Optional[str] = None
+    value: Optional[str] = None
+    notes: Optional[str] = None
+
+
+class TTPRef(BaseModel):
+    """Reference to a MITRE ATT&CK technique or similar TTP."""
+
+    ttp_id: str
+    name: Optional[str] = None
+
+
+class Actor(BaseModel):
+    """An actor participating in a scenario."""
+
+    name: str
+    role: Optional[str] = None
+
+
+class Observation(BaseModel):
+    """An observed actor performing a TTP with associated evidence."""
+
+    actor: Optional[Actor] = None
+    ttp: Optional[TTPRef] = None
+    evidence: List[Evidence] = []
+
+
+class Scenario(BaseModel):
+    """A collection of observations describing a scenario."""
+
+    name: Optional[str] = None
+    description: Optional[str] = None
+    observations: List[Observation] = []

--- a/core/scoring/__init__.py
+++ b/core/scoring/__init__.py
@@ -1,0 +1,5 @@
+"""Scoring engine utilities."""
+
+from .registry import cfg_hash, get, register
+
+__all__ = ["register", "get", "cfg_hash"]

--- a/core/scoring/base.py
+++ b/core/scoring/base.py
@@ -1,0 +1,22 @@
+"""Base types for scoring engines."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from core.schemas import Scenario
+
+
+@dataclass
+class ScoreResult:
+    """Outcome of a scoring engine."""
+
+    score: float
+    details: dict | None = None
+
+
+class Engine(Protocol):
+    """Protocol for scoring engines."""
+
+    def score(self, scenario: Scenario) -> ScoreResult: ...

--- a/core/scoring/registry.py
+++ b/core/scoring/registry.py
@@ -1,0 +1,33 @@
+"""Registry for scoring engines keyed by configuration."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Dict
+
+from .base import Engine
+
+_REGISTRY: Dict[str, Engine] = {}
+
+
+def cfg_hash(cfg: dict) -> str:
+    """Return a stable hash for a configuration dictionary."""
+
+    data = json.dumps(cfg, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(data.encode()).hexdigest()
+
+
+def register(cfg: dict, engine: Engine) -> str:
+    """Register an engine for a configuration and return its hash."""
+
+    h = cfg_hash(cfg)
+    _REGISTRY[h] = engine
+    return h
+
+
+def get(cfg: dict) -> Engine:
+    """Retrieve an engine for *cfg* raising ``KeyError`` if missing."""
+
+    h = cfg_hash(cfg)
+    return _REGISTRY[h]


### PR DESCRIPTION
## Summary
- add Pydantic domain models for Evidence, TTPRef, Actor, Observation, Scenario
- introduce scoring base types and registry for engine lookup
- expose registry helpers from `core.scoring`

## Testing
- `ruff check core/schemas core/scoring`
- `pytest` *(fails: SyntaxError: from __future__ imports must occur at the beginning of the file)*

------
https://chatgpt.com/codex/tasks/task_e_68bfa2d7b2b88324be190d1af268438e